### PR TITLE
Support Concourse CI versions of 4.0.0 or greater.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /node_modules
+.idea
+*.ipr
+*.iws
+*.iml

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Docker image
 https://hub.docker.com/r/nningego/planespotter
 
-- v3.0.0 supports concourse 3.14.1 and above
+- v4.0.0 add support for concourse 4.0.0 and above
 
 ## Needs:
 
-    API_URL [concourse API, example: https://ci.server/api/v1]
+    URL [concourse URL, example: https://ci.server]
 
     AUTH_USERNAME/AUTH_PASSWORD [basic auth credentials]
     
@@ -40,7 +40,7 @@ https://hub.docker.com/r/nningego/planespotter
     
 ### Start with docker:
     docker build . -t planespotter
-    docker run --rm -e TEAM -e API_URL -e AUTH_USERNAME -e AUTH_PASSWORD -p 3000:3000 -t planespotter
+    docker run --rm -e TEAM -e URL -e AUTH_USERNAME -e AUTH_PASSWORD -p 3000:3000 -t planespotter
     
 ### TODOs:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,29 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@infrablocks/concourse": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@infrablocks/concourse/-/concourse-0.15.0.tgz",
+      "integrity": "sha512-fDXqn8j5S4q6zEj6mahhwSUIoiUDb/BgB1vG04lo37VMUvBtZt9HhjLMzvWGhPW1ytRu2aB34bu7elMJ/MODFg==",
+      "requires": {
+        "await-lock": "1.1.3",
+        "axios": "0.18.0",
+        "camelcase-keys-deep": "0.1.0",
+        "form-urlencoded": "3.0.0",
+        "joi": "13.6.0",
+        "js-base64": "2.4.9",
+        "jsonwebtoken": "8.3.0",
+        "ramda": "0.25.0",
+        "semver": "5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -40,15 +63,6 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
-      }
-    },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -144,12 +158,8 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -169,20 +179,19 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    "await-lock": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-1.1.3.tgz",
+      "integrity": "sha512-e0jRB8X/VVxulahjW16cM1dHsO7xjyZBP8p2AnVmg2Vn3q5xJ5sTUAybmkp96+s+QcrtidSJqpCGfWhVOX7NGg=="
     },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.5.7",
+        "is-buffer": "1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -193,6 +202,39 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
       }
     },
     "balanced-match": {
@@ -206,28 +248,16 @@
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
     "binary-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
       "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
       "dev": true
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -256,6 +286,11 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
@@ -283,10 +318,19 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "camelcase-keys-deep": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys-deep/-/camelcase-keys-deep-0.1.0.tgz",
+      "integrity": "sha1-Lg3WFznJnwaO/Y3mBqYp7YCLu6M=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "chai": {
       "version": "4.1.1",
@@ -430,7 +474,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
@@ -451,6 +496,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -536,6 +582,11 @@
       "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
       "dev": true
     },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -550,29 +601,6 @@
         "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "debug": {
@@ -636,7 +664,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.1",
@@ -681,13 +710,12 @@
         "stream-shift": "1.0.0"
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "jsbn": "0.1.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "ee-first": {
@@ -1115,7 +1143,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "external-editor": {
       "version": "2.1.0",
@@ -1136,11 +1165,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -1234,6 +1258,24 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1249,20 +1291,10 @@
         "for-in": "1.0.2"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
-      }
+    "form-urlencoded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-3.0.0.tgz",
+      "integrity": "sha512-zSgBjyO5Yo3TCfElJKqlSBGOEq8lZjltZAYqew4X5trf4AbH4sZhBesvywy7IpD1mfbu8JS6733V3zv3YdIW1g=="
     },
     "formidable": {
       "version": "1.1.1",
@@ -2215,21 +2247,6 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
     "glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -2327,20 +2344,6 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
-    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -2365,21 +2368,23 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+    "hock": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/hock/-/hock-1.3.3.tgz",
+      "integrity": "sha512-bEX7KH/KSv2Q5zA+o1EdyeH52+gD2cfpYyAsHMEwjb9txXWttityKVf7cG0y3UVA4D8bxKDzH8LVXCQIr9rClg==",
+      "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "deep-equal": "0.2.1",
+        "url-equal": "0.1.2-1"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
+          "integrity": "sha1-+tenkyJMvww8d4b5LveA5PyMyHg=",
+          "dev": true
+        }
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -2396,16 +2401,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
-      }
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
       }
     },
     "iconv-lite": {
@@ -2562,8 +2557,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2709,16 +2703,26 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
+    },
+    "isemail": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
+      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
+      "requires": {
+        "punycode": "2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -2735,10 +2739,27 @@
         "isarray": "1.0.0"
       }
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    "joi": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
+      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
+      "requires": {
+        "hoek": "5.0.4",
+        "isemail": "3.1.3",
+        "topo": "3.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+        }
+      }
+    },
+    "js-base64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
+      "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2756,30 +2777,11 @@
         "esprima": "4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2790,7 +2792,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -2798,27 +2801,46 @@
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+    "jsonwebtoken": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1"
       },
       "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "1.1.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "kind-of": {
@@ -2882,7 +2904,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2967,6 +2990,11 @@
         "lodash.restparam": "3.6.1"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -2979,6 +3007,31 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -2989,6 +3042,11 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -3011,6 +3069,11 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-stream": {
       "version": "0.1.0",
@@ -3235,6 +3298,15 @@
         }
       }
     },
+    "node-rsa": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.1.tgz",
+      "integrity": "sha512-8iKs0HgkufO4Qb1iUJChh7Dg8HcSDVD37p3yu1tAhYa+/n2CwG9/d3qE+h6OHAIsfkXHEYYgbf4c7NfoMKayng==",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3"
+      }
+    },
     "nodemon": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.11.0.tgz",
@@ -3288,11 +3360,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3493,11 +3560,6 @@
         "through": "2.3.8"
       }
     },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3594,11 +3656,6 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
     "qs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
@@ -3607,8 +3664,7 @@
     "ramda": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
-      "dev": true
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -3797,65 +3853,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-        }
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.4.tgz",
-      "integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU=",
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.2"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -4028,14 +4025,6 @@
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -4083,37 +4072,10 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-combiner": {
       "version": "0.0.4",
@@ -4174,11 +4136,6 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -4328,6 +4285,21 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.4"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+        }
+      }
+    },
     "touch": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
@@ -4336,28 +4308,6 @@
       "requires": {
         "nopt": "1.0.10"
       }
-    },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -4415,6 +4365,15 @@
         "string-length": "1.0.1"
       }
     },
+    "url-equal": {
+      "version": "0.1.2-1",
+      "resolved": "https://registry.npmjs.org/url-equal/-/url-equal-0.1.2-1.tgz",
+      "integrity": "sha1-IjeVIL/gfSa1kIAEkIruEuhNBf8=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4446,23 +4405,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@infrablocks/concourse": "^0.15.0",
+    "babel-polyfill": "^6.26.0",
+    "bluebird": "^3.5.2",
     "env-var": "~2.4.3",
     "express": "~4.15.4",
     "morgan": "~1.8.2",
-    "request": "~2.81.0",
-    "request-promise-native": "~1.0.4",
     "xml": "~1.0.1"
   },
   "devDependencies": {
+    "camelcase-keys-deep": "^0.1.0",
     "chai": "~4.1.1",
     "chai-http": "~3.0.0",
     "chai-xml": "~0.3.1",
@@ -28,9 +30,13 @@
     "eslint-config-airbnb-base": "~12.1.0",
     "eslint-plugin-import": "~2.10.0",
     "eslint-plugin-mocha": "~5.0.0",
+    "form-urlencoded": "^3.0.0",
     "freeport": "~1.0.5",
+    "hock": "^1.3.3",
+    "jsonwebtoken": "^8.3.0",
     "mocha": "~3.5.0",
     "nock": "~9.0.14",
+    "node-rsa": "^1.0.1",
     "nodemon": "~1.11.0"
   }
 }

--- a/src/concourse.js
+++ b/src/concourse.js
@@ -1,78 +1,36 @@
-const request = require('request-promise-native');
+const { Client } = require('@infrablocks/concourse');
 
 class Concourse {
-  constructor(baseUri, team) {
-    this.baseUri = baseUri;
-    this.team = team;
+  constructor(url, teamName, authentication) {
+    this.teamName = teamName;
+    this.client = Client.instanceFor(
+      url.origin,
+      authentication.username,
+      authentication.password,
+      teamName,
+    );
   }
 
-  async fetchAccessToken(username, password) {
-    const fetchTokenUrl = `${this.baseUri.href}/teams/${this.team}/auth/token`;
-
-    try {
-      const basicAuthTokenResponse = await request.get({
-        url: fetchTokenUrl,
-        json: true,
-        auth: {
-          user: username,
-          password,
-        },
-      });
-      return `${basicAuthTokenResponse.type} ${basicAuthTokenResponse.value}`;
-    } catch (e) {
-      throw new Error(`Unable to fetch authorization token. Reason: ${e.message}`);
-    }
+  async fetchAllPipelines() {
+    return (await this.client.forTeam(this.teamName)).listPipelines();
   }
 
-  async fetchAllPipelines(basicAuthToken) {
-    const fetchPipelinesUrl = `${this.baseUri.href}/teams/${this.team}/pipelines`;
-    try {
-      return await request.get({
-        url: fetchPipelinesUrl,
-        json: true,
-        headers: {
-          Authorization: basicAuthToken,
-        },
-      });
-    } catch (e) {
-      throw new Error(`Unable to fetch pipeline information for url ${e.options.url}.
-      Reason: ${e.message}`);
-    }
+  async fetchAllJobs(allPipelines) {
+    const teamClient = await this.client.forTeam(this.teamName);
+    const jobsForPipelines = await Promise.all(allPipelines
+      .map(async (pipeline) => {
+        const pipelineClient = await teamClient.forPipeline(pipeline.name);
+        const pipelineJobs = await pipelineClient.listJobs();
+
+        return pipelineJobs;
+      }));
+    return jobsForPipelines.reduce((xs, x) => xs.concat(x), []);
   }
 
-  async fetchAllJobs(basicAuthToken, allPipelines) {
-    const fetchJobsUrl
-      = pipeline => `${this.baseUri.href}/teams/${this.team}/pipelines/${pipeline.name}/jobs`;
-
-    try {
-      return (await Promise.all(allPipelines.map(pipeline =>
-        request.get({
-          url: fetchJobsUrl(pipeline),
-          json: true,
-          headers: {
-            Authorization: basicAuthToken,
-          },
-        })))).reduce((xs, x) => xs.concat(x), []);
-    } catch (e) {
-      throw new Error(`Unable to fetch jobs information for url ${e.options.url}.
-      Reason: ${e.message}`);
-    }
-  }
-
-  async fetchJobResources(basicAuthToken, job) {
-    try {
-      return await request.get({
-        url: `${this.baseUri.href}/builds/${job.id}/resources`,
-        json: true,
-        headers: {
-          Authorization: basicAuthToken,
-        },
-      });
-    } catch (e) {
-      throw new Error(`Unable to fetch job resources for url ${e.options.url}.
-      Reason: ${e.message}`);
-    }
+  async fetchBuildResources(buildId) {
+    return (await this.client.forBuild(buildId)).listResources();
   }
 }
 
 module.exports = Concourse;
+

--- a/src/config.js
+++ b/src/config.js
@@ -1,16 +1,18 @@
 const env = require('env-var');
-const { URL } = require('url');
+const url = require('url');
 
 const fetchConfig = () => {
-  const API_URL = env('API_URL').required().asString();
+  const URL = env('URL').required().asString();
   const TEAM = env('TEAM').asString();
   const AUTH_USERNAME = env('AUTH_USERNAME').required().asString();
   const AUTH_PASSWORD = env('AUTH_PASSWORD').required().asString();
   return {
-    baseApiUri: new URL(API_URL),
-    team: TEAM || 'main',
-    authUsername: AUTH_USERNAME,
-    authPassword: AUTH_PASSWORD,
+    url: new url.URL(URL),
+    teamName: TEAM || 'main',
+    authentication: {
+      username: AUTH_USERNAME,
+      password: AUTH_PASSWORD,
+    },
   };
 };
 
@@ -20,10 +22,12 @@ const config = (environment) => {
       return fetchConfig();
     case 'test':
       return {
-        baseApiUri: new URL('https://ci/api/v1'),
-        team: 'main',
-        authUsername: 'some-username',
-        authPassword: 'some-password',
+        url: new url.URL('http://localhost:1337'),
+        teamName: 'main',
+        authentication: {
+          username: 'some-username',
+          password: 'some-password',
+        },
       };
     default:
       throw new Error('Must set NODE_ENV to production/test');

--- a/src/feed.js
+++ b/src/feed.js
@@ -9,27 +9,27 @@ const translateStatus = {
   aborted: 'Exception',
 };
 
-const _mapCCXML = (baseUri, job) => ({
-  name: `${job.finished_build.pipeline_name}#${job.finished_build.job_name}`,
-  activity: job.next_build ? 'Building' : 'Sleeping',
-  lastBuildStatus: translateStatus[job.finished_build.status],
-  lastBuildLabel: job.finished_build.pipeline_name,
-  lastBuildTime: job.finished_build.end_time
-  && new Date(job.finished_build.end_time * 1000).toISOString(),
-  webUrl: baseUri.origin + job.finished_build.api_url,
+const _mapCCXML = (url, job) => ({
+  name: `${job.finishedBuild.pipelineName}#${job.finishedBuild.jobName}`,
+  activity: job.nextBuild ? 'Building' : 'Sleeping',
+  lastBuildStatus: translateStatus[job.finishedBuild.status],
+  lastBuildLabel: job.finishedBuild.pipelineName,
+  lastBuildTime: job.finishedBuild.endTime
+  && new Date(job.finishedBuild.endTime * 1000).toISOString(),
+  webUrl: `${url}api/v1${job.finishedBuild.apiUrl}`,
 });
 
-const _mapJson = (baseUri, job) => ({
-  id: job.finished_build.id,
-  pipeline: job.finished_build.pipeline_name,
-  job: job.finished_build.job_name,
-  name: `${job.finished_build.pipeline_name}#${job.finished_build.job_name}`,
-  activity: job.next_build ? 'Building' : 'Sleeping',
-  lastBuildStatus: translateStatus[job.finished_build.status],
-  lastBuildLabel: job.finished_build.pipeline_name,
-  lastBuildTime: job.finished_build.end_time
-  && new Date(job.finished_build.end_time * 1000).toISOString(),
-  webUrl: baseUri.origin + job.finished_build.api_url,
+const _mapJson = (url, job) => ({
+  id: job.finishedBuild.id,
+  pipeline: job.finishedBuild.pipelineName,
+  job: job.finishedBuild.jobName,
+  name: `${job.finishedBuild.pipelineName}#${job.finishedBuild.jobName}`,
+  activity: job.nextBuild ? 'Building' : 'Sleeping',
+  lastBuildStatus: translateStatus[job.finishedBuild.status],
+  lastBuildLabel: job.finishedBuild.pipelineName,
+  lastBuildTime: job.finishedBuild.endTime
+  && new Date(job.finishedBuild.endTime * 1000).toISOString(),
+  webUrl: `${url}api/v1${job.finishedBuild.apiUrl}`,
 });
 
 const _mapResources = resources => resources.inputs
@@ -39,12 +39,12 @@ const _mapResources = resources => resources.inputs
     version,
   }));
 
-exports.toProject = (baseUri, job) => job.finished_build && {
+exports.toProject = (url, job) => job.finishedBuild && {
   Project: {
-    _attr: _mapCCXML(baseUri, job),
+    _attr: _mapCCXML(url, job),
   },
 };
 
-exports.toJobStats = (baseUri, job) => job.finished_build && _mapJson(baseUri, job);
+exports.toJobStats = (url, job) => job.finishedBuild && _mapJson(url, job);
 exports.toJobResources = resources => _mapResources(resources);
 

--- a/test/builders.js
+++ b/test/builders.js
@@ -1,32 +1,105 @@
 const chance = require('chance').Chance();
+const jwt = require('jsonwebtoken');
+const NodeRSA = require('node-rsa');
 
 const _pickRandom = list => list[Math.floor(Math.random() * list.length)];
+const _randomLowerHex = (length) => {
+  let count = length;
+  if (typeof count === 'undefined') {
+    count = 1;
+  }
+
+  let wholeString = '';
+  for (let i = 0; i < count; i += 1) {
+    wholeString += chance.pickone([
+      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+      'a', 'b', 'c', 'd', 'e', 'f',
+    ]);
+  }
+
+  return wholeString;
+};
+const _randomCsrfToken = () => _randomLowerHex(64);
+const _randomBearerToken =
+  (overrides = {}, options = {}) => {
+    const resolvedData = {
+      csrf: _randomCsrfToken(),
+      teamName: 'main',
+      isAdmin: true,
+      ...overrides,
+    };
+    const resolvedOptions = {
+      algorithm: 'RS256',
+      expiresIn: '1 day',
+      ...options,
+    };
+    const rsaPrivateKey = new NodeRSA({ b: 512 })
+      .exportKey('pkcs8-private-pem');
+
+    return jwt.sign(resolvedData, rsaPrivateKey, resolvedOptions);
+  };
+
+exports.buildToken =
+  ({
+    bearerToken = _randomBearerToken(),
+  } = {}) => ({
+    access_token: bearerToken,
+    token_type: 'Bearer',
+    expiry: '2050-09-10T07:50:24.622839253Z',
+  });
+
+exports.buildTeam =
+  ({
+    id = chance.natural(),
+    name = 'main',
+  } = {}) => ({
+    id,
+    name,
+  });
+
+exports.buildPipelineFor =
+  ({
+    id = chance.natural(),
+    name = chance.word(),
+  } = {}) => ({
+    id,
+    name,
+  });
 
 exports.buildPipelinesFor =
   ({
     pipelinesNames = [chance.word()],
   } = {}) =>
-    pipelinesNames.map(pipelineName => ({
-      id: chance.natural(),
-      name: pipelineName,
-    }));
+    pipelinesNames.map(pipelineName =>
+      exports.buildPipelineFor({ name: pipelineName }));
 
 exports.buildJobFor =
   ({
     pipelineName = chance.word(),
     jobName = chance.word(),
-    jobId = `${pipelineName}-${jobName}-id`,
+    finishedBuild = exports.buildBuildFor({ pipelineName, jobName }),
   } = {}) => ({
     next_build: null,
-    finished_build: {
-      id: jobId,
-      team_name: 'main',
-      status: 'succeeded',
-      job_name: jobName,
-      api_url: `/teams/main/pipelines/${pipelineName}/jobs/${jobName}/builds/2`,
-      pipeline_name: pipelineName,
-      end_time: 1502470729,
-    },
+    finished_build: finishedBuild,
+  });
+
+exports.buildBuildFor =
+  ({
+    teamName = 'main',
+    status = 'succeeded',
+    jobName = chance.word(),
+    pipelineName = chance.word(),
+    apiUrl = `/teams/main/pipelines/${pipelineName}/jobs/${jobName}/builds/2`,
+    endTime = 1502470729,
+    id = `${pipelineName}-${jobName}-id`,
+  } = {}) => ({
+    id,
+    team_name: teamName,
+    status,
+    job_name: jobName,
+    pipeline_name: pipelineName,
+    api_url: apiUrl,
+    end_time: endTime,
   });
 
 exports.buildResourceFor =

--- a/test/component/job-stats.spec.js
+++ b/test/component/job-stats.spec.js
@@ -1,6 +1,7 @@
 const { expect, use } = require('chai');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
+const http = require('http');
 
 const app = require('../../src/app');
 const config = require('../../src/config');
@@ -13,31 +14,62 @@ use(chaiHttp);
 describe('App', () => {
   describe('/job-stats.json', () => {
     let concourse;
+    let server;
+    let token;
+
     beforeEach(() => {
-      concourse = new ConcourseInterceptor(config.baseApiUri);
-      concourse.getAuthToken(config.authUsername, config.authPassword)
+      token = builders.buildToken();
+      concourse = new ConcourseInterceptor(
+        config.url,
+        config.teamName,
+        config.authentication,
+      );
+      concourse.onGetInfo()
         .reply(200, {
-          type: 'Bearer',
-          value: 'some-token',
+          version: '4.1.0',
         });
+      concourse.onCreateToken()
+        .reply(200, token);
+      concourse.onFetchAllTeams(token)
+        .reply(200, [builders.buildTeam({ name: config.teamName })]);
+
+      server = http.createServer(concourse.getHandler());
+      server.listen(1337);
+    });
+
+    afterEach((done) => {
+      server.close(done);
     });
 
     it('responds with status 200', (done) => {
-      concourse.getPipelines('Bearer some-token')
+      const pipeline1Name = 'pipeline1';
+      const pipeline2Name = 'pipeline2';
+      const job1Name = 'job1';
+      const job2Name = 'job2';
+
+      concourse.onFetchAllPipelines(token)
         .reply(200, builders.buildPipelinesFor({
-          pipelinesNames: ['pipeline1', 'pipeline2'],
+          pipelinesNames: [pipeline1Name, pipeline2Name],
+        }));
+      concourse.onFetchPipeline(pipeline1Name, token)
+        .reply(200, builders.buildPipelineFor({
+          name: pipeline1Name,
+        }));
+      concourse.onFetchPipeline(pipeline2Name, token)
+        .reply(200, builders.buildPipelineFor({
+          name: pipeline2Name,
         }));
 
-      concourse.getJobs('pipeline1', 'Bearer some-token')
+      concourse.onFetchAllJobs(pipeline1Name, token)
         .reply(200, builders.buildJobsFor({
-          pipelineName: 'pipeline1',
-          jobNames: ['job1', 'job2'],
+          pipelineName: pipeline1Name,
+          jobNames: [job1Name, job2Name],
         }));
 
-      concourse.getJobs('pipeline2', 'Bearer some-token')
+      concourse.onFetchAllJobs(pipeline2Name, token)
         .reply(200, builders.buildJobsFor({
-          pipelineName: 'pipeline2',
-          jobNames: ['job1', 'job2'],
+          pipelineName: pipeline2Name,
+          jobNames: [job1Name, job2Name],
         }));
 
       chai.request(app)
@@ -52,16 +84,23 @@ describe('App', () => {
     });
 
     it('responds with no projects if job has no finished builds', (done) => {
-      concourse.getPipelines('Bearer some-token')
-        .reply(200, builders.buildPipelinesFor({ pipelinesNames: ['pipeline1'] }));
+      const pipelineName = 'pipeline1';
+      const jobName = 'job1';
+
+      concourse.onFetchAllPipelines(token)
+        .reply(200, builders.buildPipelinesFor({
+          pipelinesNames: [pipelineName],
+        }));
+      concourse.onFetchPipeline(pipelineName, token)
+        .reply(200, builders.buildPipelineFor({ name: pipelineName }));
 
       const emptyJob = {
         next_build: null,
         finished_build: null,
       };
-      concourse.getJobs('pipeline1', 'Bearer some-token')
+      concourse.onFetchAllJobs(pipelineName, token)
         .reply(200, [
-          builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' }),
+          builders.buildJobFor({ pipelineName, jobName }),
           emptyJob,
         ]);
 
@@ -77,29 +116,41 @@ describe('App', () => {
     });
 
     it('responds with jobs with resources', (done) => {
-      concourse.getPipelines('Bearer some-token')
-        .reply(200, builders.buildPipelinesFor({ pipelinesNames: ['pipeline1', 'pipeline2'] }));
+      const pipeline1Name = 'pipeline1';
+      const pipeline2Name = 'pipeline2';
+      const job1Name = 'job1';
 
-      const p1Jobs = builders.buildJobsFor({
-        pipelineName: 'pipeline1',
-        jobNames: ['job1'],
-      });
-      concourse.getJobs('pipeline1', 'Bearer some-token')
-        .reply(200, p1Jobs);
+      concourse.onFetchAllPipelines(token)
+        .reply(200, builders.buildPipelinesFor({
+          pipelinesNames: [pipeline1Name, pipeline2Name],
+        }));
+      concourse.onFetchPipeline(pipeline1Name, token)
+        .reply(200, builders.buildPipelineFor({ name: pipeline1Name }));
+      concourse.onFetchPipeline(pipeline2Name, token)
+        .reply(200, builders.buildPipelineFor({ name: pipeline2Name }));
 
-      const p2Jobs = builders.buildJobsFor({
-        pipelineName: 'pipeline2',
-        jobNames: ['job1'],
+      const p1Job = builders.buildJobFor({
+        pipelineName: pipeline1Name,
+        jobName: job1Name,
       });
-      concourse.getJobs('pipeline2', 'Bearer some-token')
-        .reply(200, p2Jobs);
+      concourse.onFetchAllJobs(pipeline1Name, token)
+        .reply(200, [p1Job]);
+
+      const p2Job = builders.buildJobFor({
+        pipelineName: pipeline2Name,
+        jobName: job1Name,
+      });
+      concourse.onFetchAllJobs(pipeline2Name, token)
+        .reply(200, [p2Job]);
 
       const resource1 = builders.buildResourceFor({
         resourceName: 'resource1',
         resourceType: 'semver',
         resourceVersion: '0.1.0',
       });
-      concourse.getJobResources('pipeline1-job1-id', 'Bearer some-token')
+      concourse.onFetchBuild(p1Job.finished_build.id, token)
+        .reply(200, builders.buildBuildFor({ id: p1Job.finished_build.id }));
+      concourse.onFetchBuildResources(p1Job.finished_build.id, token)
         .reply(200, builders.buildResourcesFor({ resources: [resource1] }));
 
       const resource2 = builders.buildResourceFor({
@@ -107,7 +158,9 @@ describe('App', () => {
         resourceType: 'git',
         resourceVersion: 'cd1e2bd19e03a81132a23b2025920577f84e37',
       });
-      concourse.getJobResources('pipeline2-job1-id', 'Bearer some-token')
+      concourse.onFetchBuild(p2Job.finished_build.id, token)
+        .reply(200, builders.buildBuildFor({ id: p2Job.finished_build.id }));
+      concourse.onFetchBuildResources(p2Job.finished_build.id, token)
         .reply(200, builders.buildResourcesFor({ resources: [resource2] }));
 
       chai.request(app)
@@ -123,25 +176,42 @@ describe('App', () => {
     });
 
     it('responds with jobs with no resources', (done) => {
-      concourse.getPipelines('Bearer some-token')
-        .reply(200, builders.buildPipelinesFor({ pipelinesNames: ['pipeline1', 'pipeline2'] }));
+      const pipeline1Name = 'pipeline1';
+      const pipeline2Name = 'pipeline2';
 
-      concourse.getJobs('pipeline1', 'Bearer some-token')
-        .reply(200, builders.buildJobsFor({
-          pipelineName: 'pipeline1',
-          jobNames: ['job1'],
+      concourse.onFetchAllPipelines(token)
+        .reply(200, builders.buildPipelinesFor({
+          pipelinesNames: [pipeline1Name, pipeline2Name],
         }));
+      concourse.onFetchPipeline(pipeline1Name, token)
+        .reply(200, builders.buildPipelineFor({ name: pipeline1Name }));
+      concourse.onFetchPipeline(pipeline2Name, token)
+        .reply(200, builders.buildPipelineFor({ name: pipeline2Name }));
 
-      concourse.getJobs('pipeline2', 'Bearer some-token')
-        .reply(200, builders.buildJobsFor({
-          pipelineName: 'pipeline2',
-          jobNames: ['job1'],
-        }));
+      const job1Name = 'job1';
 
-      concourse.getJobResources('pipeline1-job1-id', 'Bearer some-token')
+      const job1 = builders.buildJobFor({
+        pipelineName: pipeline1Name,
+        jobName: job1Name,
+      });
+      concourse.onFetchAllJobs(pipeline1Name, token)
+        .reply(200, [job1]);
+
+      const job2 = builders.buildJobFor({
+        pipelineName: pipeline2Name,
+        jobName: job1Name,
+      });
+      concourse.onFetchAllJobs(pipeline2Name, token)
+        .reply(200, [job2]);
+
+      concourse.onFetchBuild(job1.finished_build.id, token)
+        .reply(200, builders.buildBuildFor({ id: job1.finished_build.id }));
+      concourse.onFetchBuildResources(job1.finished_build.id, token)
         .reply(200, builders.buildResourcesFor({ resources: [] }));
 
-      concourse.getJobResources('pipeline2-job1-id', 'Bearer some-token')
+      concourse.onFetchBuild(job2.finished_build.id, token)
+        .reply(200, builders.buildBuildFor({ id: job2.finished_build.id }));
+      concourse.onFetchBuildResources(job2.finished_build.id, token)
         .reply(200, builders.buildResourcesFor({ resources: [] }));
 
       chai.request(app)

--- a/test/resources/empty-job-response.json
+++ b/test/resources/empty-job-response.json
@@ -8,6 +8,6 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline1",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline1/jobs/job1/builds/2"
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2"
   }
 ]

--- a/test/resources/empty-job-response.xml
+++ b/test/resources/empty-job-response.xml
@@ -1,4 +1,4 @@
 <Projects>
     <Project name="pipeline1#job1" activity="Sleeping" lastBuildStatus="Success" lastBuildLabel="pipeline1"
-             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="https://ci/teams/main/pipelines/pipeline1/jobs/job1/builds/2"/>
+             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2"/>
 </Projects>

--- a/test/resources/success-response-with-empty-resources.json
+++ b/test/resources/success-response-with-empty-resources.json
@@ -8,7 +8,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline1",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline1/jobs/job1/builds/2",
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2",
     "resources": []
   },
   {
@@ -20,7 +20,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline2",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline2/jobs/job1/builds/2",
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline2/jobs/job1/builds/2",
     "resources": []
 
   }

--- a/test/resources/success-response-with-resources.json
+++ b/test/resources/success-response-with-resources.json
@@ -8,7 +8,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline1",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline1/jobs/job1/builds/2",
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2",
     "resources": [
       {
         "name": "resource1",
@@ -28,7 +28,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline2",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline2/jobs/job1/builds/2",
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline2/jobs/job1/builds/2",
     "resources": [
       {
         "name": "resource2",

--- a/test/resources/success-response.json
+++ b/test/resources/success-response.json
@@ -8,7 +8,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline1",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline1/jobs/job1/builds/2"
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2"
   },
   {
     "id": "pipeline1-job2-id",
@@ -19,7 +19,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline1",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline1/jobs/job2/builds/2"
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job2/builds/2"
   },
   {
     "id": "pipeline2-job1-id",
@@ -30,7 +30,7 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline2",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline2/jobs/job1/builds/2"
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline2/jobs/job1/builds/2"
   },
   {
     "id": "pipeline2-job2-id",
@@ -41,6 +41,6 @@
     "lastBuildStatus": "Success",
     "lastBuildLabel": "pipeline2",
     "lastBuildTime": "2017-08-11T16:58:49.000Z",
-    "webUrl": "https://ci/teams/main/pipelines/pipeline2/jobs/job2/builds/2"
+    "webUrl": "http://localhost:1337/api/v1/teams/main/pipelines/pipeline2/jobs/job2/builds/2"
   }
 ]

--- a/test/resources/success-response.xml
+++ b/test/resources/success-response.xml
@@ -1,10 +1,10 @@
 <Projects>
     <Project name="pipeline1#job1" activity="Sleeping" lastBuildStatus="Success" lastBuildLabel="pipeline1"
-             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="https://ci/teams/main/pipelines/pipeline1/jobs/job1/builds/2"/>
+             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2"/>
     <Project name="pipeline1#job2" activity="Sleeping" lastBuildStatus="Success" lastBuildLabel="pipeline1"
-             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="https://ci/teams/main/pipelines/pipeline1/jobs/job2/builds/2"/>
+             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="http://localhost:1337/api/v1/teams/main/pipelines/pipeline1/jobs/job2/builds/2"/>
     <Project name="pipeline2#job1" activity="Sleeping" lastBuildStatus="Success" lastBuildLabel="pipeline2"
-             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="https://ci/teams/main/pipelines/pipeline2/jobs/job1/builds/2"/>
+             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="http://localhost:1337/api/v1/teams/main/pipelines/pipeline2/jobs/job1/builds/2"/>
     <Project name="pipeline2#job2" activity="Sleeping" lastBuildStatus="Success" lastBuildLabel="pipeline2"
-             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="https://ci/teams/main/pipelines/pipeline2/jobs/job2/builds/2"/>
+             lastBuildTime="2017-08-11T16:58:49.000Z" webUrl="http://localhost:1337/api/v1/teams/main/pipelines/pipeline2/jobs/job2/builds/2"/>
 </Projects>

--- a/test/unit/mapper.spec.js
+++ b/test/unit/mapper.spec.js
@@ -1,12 +1,19 @@
 const { expect } = require('chai');
+const camelcaseKeysDeep = require('camelcase-keys-deep');
+
 const builders = require('../builders');
 const feed = require('../../src/feed');
 const config = require('../../src/config');
 
 describe('toProjects', () => {
   it('should map successful job to project', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    const project = feed.toProject(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+
+    const project = feed.toProject(config.url, job);
 
     expect(project).to.eql({
       Project: {
@@ -16,7 +23,7 @@ describe('toProjects', () => {
           lastBuildStatus: 'Success',
           lastBuildLabel: 'pipeline1',
           lastBuildTime: '2017-08-11T16:58:49.000Z',
-          webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+          webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
         },
       },
     });
@@ -24,19 +31,24 @@ describe('toProjects', () => {
 
   it('returns empty project if job with no build history', () => {
     const newJob = {
-      next_build: null,
-      finished_build: null,
+      nextBuild: null,
+      finishedBuild: null,
     };
 
-    const project = feed.toProject(config.baseApiUri, newJob);
+    const project = feed.toProject(config.url, newJob);
 
     expect(project).to.eql(null);
   });
 
   it('returns job as Building if next build info present', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    job.next_build = { id: 123 };
-    const project = feed.toProject(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+    job.nextBuild = { id: 123 };
+
+    const project = feed.toProject(config.url, job);
 
     expect(project).to.eql({
       Project: {
@@ -46,16 +58,21 @@ describe('toProjects', () => {
           lastBuildStatus: 'Success',
           lastBuildLabel: 'pipeline1',
           lastBuildTime: '2017-08-11T16:58:49.000Z',
-          webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+          webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
         },
       },
     });
   });
 
   it('returns failed job if status failed', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    job.finished_build.status = 'failed';
-    const project = feed.toProject(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+    job.finishedBuild.status = 'failed';
+
+    const project = feed.toProject(config.url, job);
 
     expect(project).to.eql({
       Project: {
@@ -65,16 +82,21 @@ describe('toProjects', () => {
           lastBuildStatus: 'Failure',
           lastBuildLabel: 'pipeline1',
           lastBuildTime: '2017-08-11T16:58:49.000Z',
-          webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+          webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
         },
       },
     });
   });
 
   it('returns failed job is errored', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    job.finished_build.status = 'errored';
-    const project = feed.toProject(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+    job.finishedBuild.status = 'errored';
+
+    const project = feed.toProject(config.url, job);
 
     expect(project).to.eql({
       Project: {
@@ -84,7 +106,7 @@ describe('toProjects', () => {
           lastBuildStatus: 'Failure',
           lastBuildLabel: 'pipeline1',
           lastBuildTime: '2017-08-11T16:58:49.000Z',
-          webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+          webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
         },
       },
     });
@@ -93,8 +115,13 @@ describe('toProjects', () => {
 
 describe('toJobStats', () => {
   it('should map successful job to project', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    const project = feed.toJobStats(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+
+    const project = feed.toJobStats(config.url, job);
 
     expect(project).to.eql({
       id: 'pipeline1-job1-id',
@@ -105,25 +132,30 @@ describe('toJobStats', () => {
       lastBuildStatus: 'Success',
       lastBuildLabel: 'pipeline1',
       lastBuildTime: '2017-08-11T16:58:49.000Z',
-      webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+      webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
     });
   });
 
   it('returns empty project if job with no build history', () => {
     const newJob = {
-      next_build: null,
-      finished_build: null,
+      nextBuild: null,
+      finishedBuild: null,
     };
 
-    const project = feed.toJobStats(config.baseApiUri, newJob);
+    const project = feed.toJobStats(config.url, newJob);
 
     expect(project).to.eql(null);
   });
 
   it('returns job as Building if next build info present', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    job.next_build = { id: 123 };
-    const project = feed.toJobStats(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+    job.nextBuild = { id: 123 };
+
+    const project = feed.toJobStats(config.url, job);
 
     expect(project).to.eql({
       id: 'pipeline1-job1-id',
@@ -134,14 +166,19 @@ describe('toJobStats', () => {
       lastBuildStatus: 'Success',
       lastBuildLabel: 'pipeline1',
       lastBuildTime: '2017-08-11T16:58:49.000Z',
-      webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+      webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
     });
   });
 
   it('returns failed job if status failed', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    job.finished_build.status = 'failed';
-    const project = feed.toJobStats(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+    job.finishedBuild.status = 'failed';
+
+    const project = feed.toJobStats(config.url, job);
 
     expect(project).to.eql({
       id: 'pipeline1-job1-id',
@@ -152,14 +189,19 @@ describe('toJobStats', () => {
       lastBuildStatus: 'Failure',
       lastBuildLabel: 'pipeline1',
       lastBuildTime: '2017-08-11T16:58:49.000Z',
-      webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+      webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
     });
   });
 
   it('returns failed job is errored', () => {
-    const job = builders.buildJobFor({ pipelineName: 'pipeline1', jobName: 'job1' });
-    job.finished_build.status = 'errored';
-    const project = feed.toJobStats(config.baseApiUri, job);
+    const job =
+      camelcaseKeysDeep(builders.buildJobFor({
+        pipelineName: 'pipeline1',
+        jobName: 'job1',
+      }));
+    job.finishedBuild.status = 'errored';
+
+    const project = feed.toJobStats(config.url, job);
 
     expect(project).to.eql({
       id: 'pipeline1-job1-id',
@@ -170,7 +212,7 @@ describe('toJobStats', () => {
       lastBuildStatus: 'Failure',
       lastBuildLabel: 'pipeline1',
       lastBuildTime: '2017-08-11T16:58:49.000Z',
-      webUrl: `${config.baseApiUri.origin}/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
+      webUrl: `${config.url}api/v1/teams/main/pipelines/pipeline1/jobs/job1/builds/2`,
     });
   });
 });


### PR DESCRIPTION
Hey Nishi,

Concourse 4.0.0 made a change to how authentication works and broke planespotter. `@infrablocks/concourse` has support for both the old and new authentication mechanisms so I've replaced the customer concourse client with one that delegates to the client provided by `@infrablocks/concourse`.

`@infrablocks/concourse` requires the top level URL not the API URL so this has resulted in a breaking change. 

I've had to make changes across the tests to support the new client. The most noticeable of which is switching from `nock` to `hock` which is out of process rather than in process mocking. I did this as I was having problems stubbing the authentication calls for `@infrablocks/concourse`.

Thanks,
Toby

